### PR TITLE
feat(server): add support for multiple connections

### DIFF
--- a/common.go
+++ b/common.go
@@ -5,15 +5,19 @@ import (
 	"encoding/json"
 )
 
-type NotifyFunc func(method string, params any)
-type CallFunc func(method string, params any, result any)
+type (
+	NotifyFunc func(method string, params any)
+	CallFunc   func(method string, params any, result any)
+)
 
 type Context struct {
-	Method  string
-	Params  json.RawMessage
-	Notify  NotifyFunc
-	Call    CallFunc
-	Context contextpkg.Context // can be nil
+	Method      string
+	Params      json.RawMessage
+	Notify      NotifyFunc
+	Call        CallFunc
+	CallOther   CallFunc
+	NotifyOther NotifyFunc
+	Context     contextpkg.Context // can be nil
 }
 
 type Handler interface {

--- a/server/connections.go
+++ b/server/connections.go
@@ -17,7 +17,9 @@ func (self *Server) newStreamConnection(stream io.ReadWriteCloser) *jsonrpc2.Con
 	context, cancel := contextpkg.WithTimeout(contextpkg.Background(), self.StreamTimeout)
 	defer cancel()
 
-	return jsonrpc2.NewConn(context, jsonrpc2.NewBufferedStream(stream, jsonrpc2.VSCodeObjectCodec{}), handler, connectionOptions...)
+	jsonrpc2 := jsonrpc2.NewConn(context, jsonrpc2.NewBufferedStream(stream, jsonrpc2.VSCodeObjectCodec{}), handler, connectionOptions...)
+	self.CurrentConnections = append(self.CurrentConnections, jsonrpc2)
+	return jsonrpc2
 }
 
 func (self *Server) newWebSocketConnection(socket *websocket.Conn) *jsonrpc2.Conn {
@@ -27,7 +29,9 @@ func (self *Server) newWebSocketConnection(socket *websocket.Conn) *jsonrpc2.Con
 	context, cancel := contextpkg.WithTimeout(contextpkg.Background(), self.WebSocketTimeout)
 	defer cancel()
 
-	return jsonrpc2.NewConn(context, wsjsonrpc2.NewObjectStream(socket), handler, connectionOptions...)
+	jsonrpc2 := jsonrpc2.NewConn(context, wsjsonrpc2.NewObjectStream(socket), handler, connectionOptions...)
+	self.CurrentConnections = append(self.CurrentConnections, jsonrpc2)
+	return jsonrpc2
 }
 
 func (self *Server) newConnectionOptions() []jsonrpc2.ConnOpt {

--- a/server/handler.go
+++ b/server/handler.go
@@ -27,6 +27,26 @@ func (self *Server) handle(context contextpkg.Context, connection *jsonrpc2.Conn
 				self.Log.Error(err.Error())
 			}
 		},
+		CallOther: func(method string, params any, result any) {
+			for _, conn := range self.CurrentConnections {
+				if conn == connection {
+					continue
+				}
+				if err := conn.Call(context, method, params, result); err != nil {
+					self.Log.Error(err.Error())
+				}
+			}
+		},
+		NotifyOther: func(method string, params any) {
+			for _, conn := range self.CurrentConnections {
+				if conn == connection {
+					continue
+				}
+				if err := conn.Notify(context, method, params); err != nil {
+					self.Log.Error(err.Error())
+				}
+			}
+		},
 		Context: context,
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -3,20 +3,25 @@ package server
 import (
 	"time"
 
+	"github.com/sourcegraph/jsonrpc2"
 	"github.com/tliron/commonlog"
 	"github.com/tliron/glsp"
 )
 
-var DefaultTimeout = time.Minute
+var (
+	DefaultTimeout     = time.Minute
+	currentConnections []*jsonrpc2.Conn
+)
 
 //
 // Server
 //
 
 type Server struct {
-	Handler     glsp.Handler
-	LogBaseName string
-	Debug       bool
+	Handler            glsp.Handler
+	LogBaseName        string
+	Debug              bool
+	CurrentConnections []*jsonrpc2.Conn
 
 	Log              commonlog.Logger
 	Timeout          time.Duration
@@ -28,14 +33,15 @@ type Server struct {
 
 func NewServer(handler glsp.Handler, logName string, debug bool) *Server {
 	return &Server{
-		Handler:          handler,
-		LogBaseName:      logName,
-		Debug:            debug,
-		Log:              commonlog.GetLogger(logName),
-		Timeout:          DefaultTimeout,
-		ReadTimeout:      DefaultTimeout,
-		WriteTimeout:     DefaultTimeout,
-		StreamTimeout:    DefaultTimeout,
-		WebSocketTimeout: DefaultTimeout,
+		Handler:            handler,
+		LogBaseName:        logName,
+		Debug:              debug,
+		CurrentConnections: currentConnections,
+		Log:                commonlog.GetLogger(logName),
+		Timeout:            DefaultTimeout,
+		ReadTimeout:        DefaultTimeout,
+		WriteTimeout:       DefaultTimeout,
+		StreamTimeout:      DefaultTimeout,
+		WebSocketTimeout:   DefaultTimeout,
 	}
 }


### PR DESCRIPTION
This commit introduces the ability to handle multiple connections in the server. It adds two new methods, CallOther and NotifyOther, to the Context struct in common.go. These methods are used to call or notify all other connections, excluding the current one.

In server.go, a new slice CurrentConnections is added to the Server struct to keep track of all active connections. This slice is updated whenever a new connection is established.

In handler.go, the CallOther and NotifyOther methods are implemented. They iterate over the CurrentConnections slice and call or notify each connection, skipping the current one.

In connections.go, the newStreamConnection and newWebSocketConnection methods are updated to add the new connection to the CurrentConnections slice.